### PR TITLE
show likes list

### DIFF
--- a/src/Components/GeneralComponents/LikesModal/LikesModal.css
+++ b/src/Components/GeneralComponents/LikesModal/LikesModal.css
@@ -1,0 +1,33 @@
+.likes-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.likes-modal {
+  background: white;
+  padding: 20px;
+  border-radius: 10px;
+  width: 300px;
+  max-height: 400px;
+  overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.close-button-likes-modal {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  cursor: pointer;
+}

--- a/src/Components/GeneralComponents/LikesModal/LikesModal.js
+++ b/src/Components/GeneralComponents/LikesModal/LikesModal.js
@@ -1,0 +1,18 @@
+import React from "react";
+import "./LikesModal.css";
+
+export default function LikesModal({ users, onClose }) {
+  return (
+    <div className="likes-modal-overlay">
+      <div className="likes-modal">
+        <button className="close-button-likes-modal" onClick={onClose}>❌</button>
+        <h3>Liked by</h3>
+        <ul>
+          {users.map((user, index) => (
+            <li key={index}>@{user.username || "Unknown"}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/src/Components/UserPages/HomePage/HomePage.css
+++ b/src/Components/UserPages/HomePage/HomePage.css
@@ -366,16 +366,25 @@
     cursor: pointer;
   }
 
-  .delete-photo-btn {
+    .delete-photo-btn {
     position: absolute;
-    top: 12px;
-    right: 48px;
+    top: 50px;            
+    left: 750px;          
     background: none;
     border: none;
     font-size: 22px;
     cursor: pointer;
     color: #e74c3c;
     transition: transform 0.2s ease;
+    z-index: 11;
+  }
+
+  @media (max-width: 768px) {
+    .delete-photo-btn {
+      top: 45px;         
+      right: 12px;        
+      font-size: 20px;
+    }
   }
   
   .delete-photo-btn:hover {

--- a/src/Components/UserPages/HomePage/HomePage.js
+++ b/src/Components/UserPages/HomePage/HomePage.js
@@ -8,6 +8,8 @@ import SearchBar from "../../GeneralComponents/SearchBar/SearchBar";
 import ClickableLogo from "../../ClickableLogo";
 import { uploadProfilePicture, deleteProfilePicture, deleteUserPhoto, getAlbumPhotos, getUserAlbums, getPostByImageUrl, getUserById, getUsernameById } from "../../API/user-account";
 import { likePost, unlikePost, getLikes, getComments, addComment } from "../../API/post-interactions";
+import LikesModal from "../../GeneralComponents/LikesModal/LikesModal";
+import "../../GeneralComponents/LikesModal/LikesModal.css";
 
 export default function HomePage() {
 
@@ -30,6 +32,9 @@ export default function HomePage() {
   const [commentsMap, setCommentsMap] = useState({});
   const [newComment, setNewComment] = useState({});
   const [likedPosts, setLikedPosts] = useState(new Set());
+  const [showLikesModal, setShowLikesModal] = useState(false);
+  const [modalLikesUsers, setModalLikesUsers] = useState([]);
+
 
   const [usernamesById, setUsernamesById] = useState({});
   
@@ -250,6 +255,16 @@ export default function HomePage() {
       }
     });
   };
+
+  const handleShowLikes = (postId) => {
+  const users = (likesMap[postId] || []).map(u => ({
+    ...u,
+    username: usernamesById[u.id] || "..."
+  }));
+  setModalLikesUsers(users);
+  setShowLikesModal(true);
+};
+
   
   const handleDragOver = (event) => {
     event.preventDefault();
@@ -387,7 +402,17 @@ export default function HomePage() {
                 <button onClick={() => handleToggleLike(activePhotoPostId)}>
                   {likedPosts.has(activePhotoPostId) ? "💔 Unlike" : "❤️ Like"}
                 </button>
-                <span>Total: {likesMap[activePhotoPostId]?.length || 0}</span>
+                <span
+                  style={{ cursor: "pointer", textDecoration: "underline" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleShowLikes(activePhotoPostId);
+                  }}
+                >
+                  Total: {likesMap[activePhotoPostId]?.length || 0}
+                </span>
+
+
               </div>
               <div className="comments">
                 <h4>Comments</h4>
@@ -455,7 +480,17 @@ export default function HomePage() {
                 <button onClick={() => handleToggleLike(activeAlbumPostId)}>
                   {likedPosts.has(activeAlbumPostId) ? "💔 Unlike" : "❤️ Like"}
                 </button>
-                <span>Total: {likesMap[activeAlbumPostId]?.length || 0}</span>
+                <span
+                  style={{ cursor: "pointer", textDecoration: "underline" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleShowLikes(activeAlbumPostId);
+                  }}
+                >
+                  Total: {likesMap[activeAlbumPostId]?.length || 0}
+                </span>
+
+
               </div>
               <div className="comments">
                 <h4>Comments</h4>
@@ -483,6 +518,12 @@ export default function HomePage() {
             </div>
           </div>
         </div>
+      )}
+      {showLikesModal && (
+        <LikesModal
+          users={modalLikesUsers}
+          onClose={() => setShowLikesModal(false)}
+        />
       )}
 
     </div>

--- a/src/Components/UserPages/ViewProfilePage/ViewProfile.js
+++ b/src/Components/UserPages/ViewProfilePage/ViewProfile.js
@@ -6,6 +6,9 @@ import { getUserById, getUserPhotos, getPostByImageUrl, getUsernameById } from "
 import { likePost, unlikePost, getLikes, getComments, addComment } from "../../API/post-interactions";
 import SearchBar from "../../GeneralComponents/SearchBar/SearchBar";
 import ClickableLogo from "../../ClickableLogo";
+import LikesModal from "../../GeneralComponents/LikesModal/LikesModal";
+import "../../GeneralComponents/LikesModal/LikesModal.css";
+
 
 export default function ViewProfilePage() {
   const { id } = useParams();
@@ -23,6 +26,9 @@ export default function ViewProfilePage() {
   const [commentsMap, setCommentsMap] = useState({});
   const [newComment, setNewComment] = useState({});
   const [likedPosts, setLikedPosts] = useState(new Set());
+  const [showLikesModal, setShowLikesModal] = useState(false);
+  const [modalLikesUsers, setModalLikesUsers] = useState([]);
+
 
   const currentUser = JSON.parse(localStorage.getItem("user")) || {};
 
@@ -210,6 +216,16 @@ export default function ViewProfilePage() {
   setActivePhotoPostId(null);      
 };
 
+const handleShowLikes = (postId) => {
+  const users = (likesMap[postId] || []).map(u => ({
+    ...u,
+    username: usernamesById[u.id] || "..."
+  }));
+  setModalLikesUsers(users);
+  setShowLikesModal(true);
+};
+
+
 
   return (
     <div className="homepage-container">
@@ -288,7 +304,17 @@ export default function ViewProfilePage() {
                 <button onClick={() => handleToggleLike(activePhotoPostId)}>
                   {likedPosts.has(activePhotoPostId) ? "💔 Unlike" : "❤️ Like"}
                 </button>
-                <span>Total: {likesMap[activePhotoPostId]?.length || 0}</span>
+                <span
+                    style={{ cursor: "pointer", textDecoration: "underline" }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleShowLikes(activePhotoPostId);
+                    }}
+                  >
+                    Total: {likesMap[activePhotoPostId]?.length || 0}
+                  </span>
+
+
               </div>
               <div className="desc"><b>Description:</b> Poza adăugată de utilizator</div>
               <div className="comments">
@@ -347,7 +373,17 @@ export default function ViewProfilePage() {
                 <button onClick={() => handleToggleLike(activeAlbumPostId)}>
                   {likedPosts.has(activeAlbumPostId) ? "💔 Unlike" : "❤️ Like"}
                 </button>
-                <span>Total: {likesMap[activeAlbumPostId]?.length || 0}</span>
+               <span
+                  style={{ cursor: "pointer", textDecoration: "underline" }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleShowLikes(activeAlbumPostId);
+                  }}
+                >
+                  Total: {likesMap[activeAlbumPostId]?.length || 0}
+                </span>
+
+
               </div>
               <div className="desc"><b>Description:</b> {activeAlbum.name}</div>
               <div className="comments">
@@ -378,6 +414,12 @@ export default function ViewProfilePage() {
             </div>
           </div>
         </div>
+      )}
+      {showLikesModal && (
+        <LikesModal
+          users={modalLikesUsers}
+          onClose={() => setShowLikesModal(false)}
+        />
       )}
 
     </div>


### PR DESCRIPTION
![3](https://github.com/user-attachments/assets/af3fe78f-cac8-4cd3-a574-94c75ba8e85c)
This PR implements a modal that shows the list of users who liked a specific post or photo.
It includes the following changes:
Created a reusable LikesModal component.
Fetched usernames based on user IDs from the backend.
Added logic to open the modal when the "Total likes" count is clicked.
Displayed usernames in a scrollable modal popup.
Responsive design adjustments for modal on smaller screens.